### PR TITLE
getter fix for ionic controls

### DIFF
--- a/src/input-control.ts
+++ b/src/input-control.ts
@@ -155,7 +155,7 @@ const ctrlElmRef = (
 ) => {
   // we just got a reference to the control input element
   let ctrlId = ctrlElm.getAttribute('id');
-  let ctrlName = ctrlElm.getAttribute('name');
+  let ctrlName = ctrlElm.getAttribute('name') || ctrlElm.name;
   let labellingElm = labellingElms[LabellingType.labelledby].get(ctrl);
 
   if (!ctrlId) {


### PR DESCRIPTION
Hi Adam,

I'm adding some ionic components to my forms. The issue is that they don't reflect the `name` attribute:
https://github.com/ionic-team/ionic-framework/blob/c1455a839a25e3e23b7c9e7b7d930055b24c2ecb/core/src/components/input/input.tsx#L144

Which causes `getAttribute` to return null instead of the correct value:
https://github.com/adamdbradley/stencil-forms/blob/f0a64a10501343f6a8b9c7052969875c81acf2d1/src/input-control.ts#L158

Demo code inside a form:
```
<form>
   <ion-input name='fullname' ... />
</form>
```

... will cause thew `ion-input` to being assigned a random `ctrlXX` name which is bad cause this will be used as the form control key in the form data.